### PR TITLE
replace ubuntu with alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,85 +1,68 @@
-FROM ubuntu:14.04
+FROM gliderlabs/alpine:latest
 MAINTAINER RightsUp <it@rightsup.com>
 
 # Set Locales to prevent encoding mismatch errors in child containers.
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8 
+# RUN locale-gen en_US.UTF-8  
+# ENV LANG en_US.UTF-8  
+# ENV LANGUAGE en_US:en  
+# ENV LC_ALL en_US.UTF-8 
 
-RUN apt-get update && apt-get install -y \
+
+RUN apk-install \   
+  ## ruby
+  ruby \
+  ruby-nokogiri \
+  ruby-bundler \
+  ruby-io-console \
+  ruby-bigdecimal \
+  ruby-rake \
+  ## utils
+  bash \
+  curl \
+  git \
+  wget \
+  ## build
   autoconf \
   bison \
-  curl \
-  wget \
-  git \
-  nano \
-  vim \
-  tmux \
-  g++ \
-  postgresql-client \
-  phantomjs \
-  build-essential \
-  libssl-dev \
-  libyaml-dev \
-  libreadline6-dev \
-  zlib1g-dev \
-  libncurses5-dev \
+  ## libraries
+  gdbm-dev \
+  libev-dev \
   libffi-dev \
-  libgdbm3 \
-  libgdbm-dev \
-  libpq-dev \
-  libsqlite3-dev \
-  libxml2-dev \
-  libxslt1-dev \
-  libcurl4-openssl-dev \
-  libffi-dev
+  libpq \
+  ncurses-dev \
+  openssl-dev \
+  readline-dev \
+  sqlite-libs \
+  yaml-dev \
+  zlib-dev \
+  libstdc++ \
+  # build stuff
+  cmake \
+  build-base
 
-RUN git clone https://github.com/sstephenson/rbenv.git /root/.rbenv
-RUN git clone https://github.com/sstephenson/ruby-build.git /root/.rbenv/plugins/ruby-build
-RUN git clone https://github.com/sstephenson/rbenv-gem-rehash.git /root/.rbenv/plugins/rbenv-gem-rehash
-ENV PATH /root/.rbenv/shims:/root/.rbenv/bin:$PATH
-RUN echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh # or /etc/profile
-RUN echo 'eval "$(rbenv init -)"' >> .bashrc
-
+# Ruby Config
 ENV CONFIGURE_OPTS --disable-install-doc
-# Add More Ruby Versions Here
-# And install slow or universally required gems (nokogiri is slow, bundler is universal)
-RUN rbenv install 2.0.0-p647
-RUN rbenv install 2.2.3
+RUN echo 'gem: --no-rdoc --no-ri' >> /etc/gemrc
+RUN gem update --system
+RUN gem install bundler
+RUN gem sources -c
 
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 
-# Ruby 2.0.0
-RUN rbenv global 2.0.0-p647
-RUN gem install bundler nokogiri
+# Installs libcouchbase. Used in multiple child services
+# Version 2.5.4 Check for updates occasionally. 
+# TODO: build apk package, put in Alpine repo
+RUN cd /tmp &&  \
+    wget http://packages.couchbase.com/clients/c/libcouchbase-2.5.4.tar.gz && \
+    ls && \
+    tar -xzf libcouchbase-2.5.4.tar.gz && \
+    cd libcouchbase-2.5.4 && \
+    ./configure.pl && \
+    make install && \
+    cd / && rm -rf /tmp/*
 
-# Ruby 2.2.3
-RUN rbenv global 2.2.3
-RUN gem install bundler nokogiri
+#Cleanup large build essentials
+RUN apk del \
+    cmake \
+    build-base
 
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 4.2.1
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --verify SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
-
-RUN npm install -g npm
-
-CMD ['bash']
+CMD bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,9 @@
 FROM gliderlabs/alpine:latest
 MAINTAINER RightsUp <it@rightsup.com>
 
-# Set Locales to prevent encoding mismatch errors in child containers.
-# RUN locale-gen en_US.UTF-8  
-# ENV LANG en_US.UTF-8  
-# ENV LANGUAGE en_US:en  
-# ENV LC_ALL en_US.UTF-8 
-
-
 RUN apk-install \   
   ## ruby
   ruby \
-  ruby-nokogiri \
-  ruby-bundler \
   ruby-io-console \
   ruby-bigdecimal \
   ruby-rake \
@@ -21,24 +12,15 @@ RUN apk-install \
   curl \
   git \
   wget \
-  ## build
-  autoconf \
-  bison \
-  ## libraries
-  gdbm-dev \
-  libev-dev \
-  libffi-dev \
-  libpq \
-  ncurses-dev \
-  openssl-dev \
-  readline-dev \
-  sqlite-libs \
-  yaml-dev \
-  zlib-dev \
-  libstdc++ \
-  # build stuff
-  cmake \
-  build-base
+  # postgers
+  libpq 
+
+
+# TODO: Replace with apk-install pending acceptance of http://lists.alpinelinux.org/alpine-aports/0128.html
+RUN curl -Ls https://github.com/gerbal/alpine-libcouchbase/releases/download/2.5.4/libcouchbase-2.5.4-r0.apk > /tmp/libcouchbase.apk && \ 
+    curl -Ls https://github.com/gerbal/alpine-libcouchbase/releases/download/2.5.4/libcouchbase-dev-2.5.4-r0.apk > /tmp/libcouchbase-dev.apk && \ 
+    apk-install --allow-untrusted /tmp/libcouchbase.apk /tmp/libcouchbase-dev.apk&& \
+    rm /tmp/libcouchbase-dev.apk /tmp/libcouchbase.apk 
 
 # Ruby Config
 ENV CONFIGURE_OPTS --disable-install-doc
@@ -46,23 +28,5 @@ RUN echo 'gem: --no-rdoc --no-ri' >> /etc/gemrc
 RUN gem update --system
 RUN gem install bundler
 RUN gem sources -c
-
-
-# Installs libcouchbase. Used in multiple child services
-# Version 2.5.4 Check for updates occasionally. 
-# TODO: build apk package, put in Alpine repo
-RUN cd /tmp &&  \
-    wget http://packages.couchbase.com/clients/c/libcouchbase-2.5.4.tar.gz && \
-    ls && \
-    tar -xzf libcouchbase-2.5.4.tar.gz && \
-    cd libcouchbase-2.5.4 && \
-    ./configure.pl && \
-    make install && \
-    cd / && rm -rf /tmp/*
-
-#Cleanup large build essentials
-RUN apk del \
-    cmake \
-    build-base
 
 CMD bash

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,11 @@
 This is a simple docker to provide the default environment we run a lot of our apps in.
 
-It includes Ruby 2.0.0 & 2.2.3 for use with rbenv prebuilt and Nodejs 4.2.1 built on Ubuntu 14.04.
+It includes Ruby lastest stable and is built from [Alpine](http://www.alpinelinux.org/).
+
+Alpine is very lightweight (5mb), And has good [package support](https://pkgs.alpinelinux.org/packages). But not as diverse as Ubuntu So it may be necessary to package or build some libraries and tools. 
+
+Libcouchbase has been packaged for Alpine [here](https://github.com/gerbal/alpine-libcouchbase). Hopefully it will be in the Alpine APK repository soon, but if not we can keep installing it manually. 
+
+The image also includes ruby and a few commonly used utilities.
 
 To use it, replace `FROM ubuntu:14.04` with `FROM rightsup/base`


### PR DESCRIPTION
Apline is much lighter than Ubuntu and should allow for much smaller docker containers and images.

Alpine weighs ~5mb vs ~200mb for Ubuntu. 

This should follow updating to recent stable Ruby. 

todo:
- [x] Need to figure out how to set locales
- [x] verify all child dependencies are satisfied. 
- [x] Update Readme
